### PR TITLE
Change 'name' variable to 'names' for a list of profiles to manage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # terraform-aws-eks-fargate-profile
 
-Terraform module to provision an EKS Node Group for [Elastic Container Service for Kubernetes](https://aws.amazon.com/eks/).
-
-Instantiate it multiple times to create many EKS node groups with specific settings such as GPUs, EC2 instance types, or autoscale parameters.
+Terraform module to provision an EKS Fargate Profiles for [Elastic Container Service for Kubernetes](https://aws.amazon.com/eks/).
 
 Based on [Terraform Resource](https://www.terraform.io/docs/providers/aws/r/eks_fargate_profile.html)
 
@@ -18,7 +16,7 @@ Here's the gist of using it directly from github.
       tags                 = var.tags
       subnet_ids           = var.subnet_ids
       cluster_name         = var.cluster_name
-      namespace            = var.namespace
+      namespaces            = var.namespaces
       labels               = var.labels
     }
 ```
@@ -48,9 +46,8 @@ Here's the gist of using it directly from github.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | cluster\_name | Cluster name | `string` | n/a | yes |
-| enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
 | labels | Key-value mapping of Kubernetes labels for selection | `map(string)` | `{}` | no |
-| namespace | Kubernetes namespace for selection | `string` | n/a | yes |
+| namespaces | Kubernetes namespaces for selection (set to an empty string to disable resource creation) | `list(string)` | n/a | yes |
 | subnet\_ids | Identifiers of private EC2 Subnets to associate with the EKS Fargate Profile. These subnets must have the following resource tag: kubernetes.io/cluster/CLUSTER\_NAME (where CLUSTER\_NAME is replaced with the name of the EKS Cluster) | `list(string)` | n/a | yes |
 | suffix | Suffix added to the name. In case we need more then one profile in same namespace | `string` | `""` | no |
 | tags | Additional tags (e.g. `{ Deployed = "xxxx" }` | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -29,8 +29,9 @@ resource aws_iam_role this {
 
 resource aws_iam_role_policy_attachment attachment_main {
   #count      = var.enabled ? 1 : 0
+  for_each   = toset(var.namespaces)
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
-  role       = join("", aws_iam_role.this[*].name)
+  role       = aws_iam_role.this[each.value].name
 }
 
 resource aws_eks_fargate_profile this {
@@ -38,7 +39,7 @@ resource aws_eks_fargate_profile this {
   for_each               = toset(var.namespaces)
   cluster_name           = var.cluster_name
   fargate_profile_name   = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)
-  pod_execution_role_arn = join("", aws_iam_role.this[*].arn)
+  pod_execution_role_arn = aws_iam_role.this[each.value].arn
   subnet_ids             = var.subnet_ids
 
   tags = merge(var.tags,

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource aws_iam_role this {
   #count              = var.enabled ? 1 : 0
   for_each           = toset(var.namespaces)
   name               = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)
-  assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
+  assume_role_policy = join("", data.aws_iam_policy_document.assume_role.json)
   tags = merge(var.tags,
     { Namespace = each.value },
     { "kubernetes.io/cluster/${var.cluster_name}" = "owned" },
@@ -30,7 +30,7 @@ resource aws_iam_role this {
 resource aws_iam_role_policy_attachment attachment_main {
   #count      = var.enabled ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
-  role       = join("", aws_iam_role.this.*.name)
+  role       = join("", aws_iam_role.this[*].name)
 }
 
 resource aws_eks_fargate_profile this {
@@ -38,7 +38,7 @@ resource aws_eks_fargate_profile this {
   for_each               = toset(var.namespaces)
   cluster_name           = var.cluster_name
   fargate_profile_name   = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)
-  pod_execution_role_arn = join("", aws_iam_role.this.*.arn)
+  pod_execution_role_arn = join("", aws_iam_role.this[*].arn)
   subnet_ids             = var.subnet_ids
 
   tags = merge(var.tags,

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource aws_iam_role this {
   #count              = var.enabled ? 1 : 0
   for_each           = toset(var.namespaces)
   name               = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)
-  assume_role_policy = join("", data.aws_iam_policy_document.assume_role.json)
+  assume_role_policy =  data.aws_iam_policy_document.assume_role.json
   tags = merge(var.tags,
     { Namespace = each.value },
     { "kubernetes.io/cluster/${var.cluster_name}" = "owned" },

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data aws_iam_policy_document assume_role {
 resource aws_iam_role this {
   for_each           = toset(var.namespaces)
   name               = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)
-  assume_role_policy =  data.aws_iam_policy_document.assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
   tags = merge(var.tags,
     { Namespace = each.value },
     { "kubernetes.io/cluster/${var.cluster_name}" = "owned" },

--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,6 @@ locals {
 }
 
 data aws_iam_policy_document assume_role {
-  #count = var.enabled ? 1 : 0
-
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -17,7 +15,6 @@ data aws_iam_policy_document assume_role {
 }
 
 resource aws_iam_role this {
-  #count              = var.enabled ? 1 : 0
   for_each           = toset(var.namespaces)
   name               = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)
   assume_role_policy =  data.aws_iam_policy_document.assume_role.json
@@ -28,14 +25,12 @@ resource aws_iam_role this {
 }
 
 resource aws_iam_role_policy_attachment attachment_main {
-  #count      = var.enabled ? 1 : 0
   for_each   = toset(var.namespaces)
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
   role       = aws_iam_role.this[each.value].name
 }
 
 resource aws_eks_fargate_profile this {
-  #count                  = var.enabled ? 1 : 0
   for_each               = toset(var.namespaces)
   cluster_name           = var.cluster_name
   fargate_profile_name   = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 data aws_iam_policy_document assume_role {
-  count = var.enabled ? 1 : 0
+  #count = var.enabled ? 1 : 0
 
   statement {
     effect  = "Allow"
@@ -17,7 +17,7 @@ data aws_iam_policy_document assume_role {
 }
 
 resource aws_iam_role this {
-  count              = var.enabled ? 1 : 0
+  #count              = var.enabled ? 1 : 0
   for_each           = toset(var.namespaces)
   name               = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)
   assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
@@ -28,13 +28,13 @@ resource aws_iam_role this {
 }
 
 resource aws_iam_role_policy_attachment attachment_main {
-  count      = var.enabled ? 1 : 0
+  #count      = var.enabled ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
   role       = join("", aws_iam_role.this.*.name)
 }
 
 resource aws_eks_fargate_profile this {
-  count                  = var.enabled ? 1 : 0
+  #count                  = var.enabled ? 1 : 0
   for_each               = toset(var.namespaces)
   cluster_name           = var.cluster_name
   fargate_profile_name   = format("%s-fargate-%s%s", var.cluster_name, each.value, local.suffix)

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,26 +1,25 @@
-# Temporarily disable all outputs.
 
-# output "eks_fargate_profile_role_arn" {
-#   description = "ARN of the EKS Fargate Profile IAM role"
-#   value       = join("", aws_iam_role.this.*.arn)
-# }
+output "eks_fargate_profile_role_arn" {
+  description = "ARN of the EKS Fargate Profile IAM role"
+  value       = join(",", aws_iam_role.this.*.arn)
+}
 
-# output "eks_fargate_profile_role_name" {
-#   description = "Name of the EKS Fargate Profile IAM role"
-#   value       = join("", aws_iam_role.this.*.name)
-# }
+output "eks_fargate_profile_role_name" {
+  description = "Name of the EKS Fargate Profile IAM role"
+  value       = join(",", aws_iam_role.this.*.name)
+}
 
-# output "eks_fargate_profile_id" {
-#   description = "EKS Cluster name and EKS Fargate Profile name separated by a colon"
-#   value       = join("", aws_eks_fargate_profile.this.*.id)
-# }
+output "eks_fargate_profile_id" {
+  description = "EKS Cluster name and EKS Fargate Profile name separated by a colon"
+  value       = join(",", aws_eks_fargate_profile.this.*.id)
+}
 
-# output "eks_fargate_profile_arn" {
-#   description = "Amazon Resource Name (ARN) of the EKS Fargate Profile"
-#   value       = join("", aws_eks_fargate_profile.this.*.arn)
-# }
+output "eks_fargate_profile_arn" {
+  description = "Amazon Resource Name (ARN) of the EKS Fargate Profile"
+  value       = join(",", aws_eks_fargate_profile.this.*.arn)
+}
 
-# output "eks_fargate_profile_status" {
-#   description = "Status of the EKS Fargate Profile"
-#   value       = join("", aws_eks_fargate_profile.this.*.status)
-# }
+output "eks_fargate_profile_status" {
+  description = "Status of the EKS Fargate Profile"
+  value       = join(",", aws_eks_fargate_profile.this.*.status)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,26 @@
-output "eks_fargate_profile_role_arn" {
-  description = "ARN of the EKS Fargate Profile IAM role"
-  value       = join("", aws_iam_role.this.*.arn)
-}
+# Temporarily disable all outputs.
 
-output "eks_fargate_profile_role_name" {
-  description = "Name of the EKS Fargate Profile IAM role"
-  value       = join("", aws_iam_role.this.*.name)
-}
+# output "eks_fargate_profile_role_arn" {
+#   description = "ARN of the EKS Fargate Profile IAM role"
+#   value       = join("", aws_iam_role.this.*.arn)
+# }
 
-output "eks_fargate_profile_id" {
-  description = "EKS Cluster name and EKS Fargate Profile name separated by a colon"
-  value       = join("", aws_eks_fargate_profile.this.*.id)
-}
+# output "eks_fargate_profile_role_name" {
+#   description = "Name of the EKS Fargate Profile IAM role"
+#   value       = join("", aws_iam_role.this.*.name)
+# }
 
-output "eks_fargate_profile_arn" {
-  description = "Amazon Resource Name (ARN) of the EKS Fargate Profile"
-  value       = join("", aws_eks_fargate_profile.this.*.arn)
-}
+# output "eks_fargate_profile_id" {
+#   description = "EKS Cluster name and EKS Fargate Profile name separated by a colon"
+#   value       = join("", aws_eks_fargate_profile.this.*.id)
+# }
 
-output "eks_fargate_profile_status" {
-  description = "Status of the EKS Fargate Profile"
-  value       = join("", aws_eks_fargate_profile.this.*.status)
-}
+# output "eks_fargate_profile_arn" {
+#   description = "Amazon Resource Name (ARN) of the EKS Fargate Profile"
+#   value       = join("", aws_eks_fargate_profile.this.*.arn)
+# }
+
+# output "eks_fargate_profile_status" {
+#   description = "Status of the EKS Fargate Profile"
+#   value       = join("", aws_eks_fargate_profile.this.*.status)
+# }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,25 +1,25 @@
 
 output "eks_fargate_profile_role_arn" {
   description = "ARN of the EKS Fargate Profile IAM role"
-  value       = join(",", aws_iam_role.this.*.arn)
+  value       = [for entry in aws_iam_role.this : entry.arn]
 }
 
 output "eks_fargate_profile_role_name" {
   description = "Name of the EKS Fargate Profile IAM role"
-  value       = join(",", aws_iam_role.this.*.name)
+  value       = [for entry in aws_iam_role.this : entry.name]
 }
 
 output "eks_fargate_profile_id" {
   description = "EKS Cluster name and EKS Fargate Profile name separated by a colon"
-  value       = join(",", aws_eks_fargate_profile.this.*.id)
+  value       = [for entry in aws_eks_fargate_profile.this : entry.id]
 }
 
 output "eks_fargate_profile_arn" {
   description = "Amazon Resource Name (ARN) of the EKS Fargate Profile"
-  value       = join(",", aws_eks_fargate_profile.this.*.arn)
+  value       = [for entry in aws_eks_fargate_profile.this : entry.arn]
 }
 
 output "eks_fargate_profile_status" {
   description = "Status of the EKS Fargate Profile"
-  value       = join(",", aws_eks_fargate_profile.this.*.status)
+  value       = [for entry in aws_eks_fargate_profile.this : entry.status]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,9 +20,9 @@ variable "tags" {
   description = "Additional tags (e.g. `{ Deployed = \"xxxx\" }`"
 }
 
-variable "namespace" {
-  type        = string
-  description = "Kubernetes namespace for selection"
+variable "namespaces" {
+  type        = list(string)
+  description = "Kubernetes namespace(s) for selection.  Adding more than one namespace, creates and manages multiple namespaces."
 }
 
 variable "labels" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "enabled" {
-  type        = bool
-  description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
-  default     = true
-}
-
 variable "cluster_name" {
   type        = string
   description = "Cluster name"


### PR DESCRIPTION
This PR adds the ability to manage multiple profile instances based of user input variable, instead of hard coding them into the TF scripts. 

BREAKING CHANGES:
- changes 'name' to 'names' which is a change from a string to a list of strings.
- removes the need for the 'enabled' variable
- changes the outputs to a string of comma separated values.